### PR TITLE
fix(Window.vue): full windowed emit resize end

### DIFF
--- a/src/components/WindowBasic/Window.vue
+++ b/src/components/WindowBasic/Window.vue
@@ -251,6 +251,7 @@ export default {
       this.$emit("resize_start")
       this.refocus()
       if (this.full_windowed) {
+        this.$emit("resize_end")
         return ;
       }
       let orn_mousedown = document.onmousedown;


### PR DESCRIPTION
修复浏览器放大后点击WindowHeader之后show_blocker不会消失